### PR TITLE
Don't let the errno leak into the global scope.

### DIFF
--- a/example/mirrorFS.js
+++ b/example/mirrorFS.js
@@ -46,7 +46,7 @@ var errnoMap = {
 };
 
 function excToErrno(exc) {
-  errno = errnoMap[exc.code];
+  var errno = errnoMap[exc.code];
   if (!errno)
     errno = errnoMap.EPERM; // default to EPERM
   return errno;


### PR DESCRIPTION
Don't let the errno leak into the global scope in the mirrorFS example.

By the way, this is some _great_ work! I'm currently working on storing all my mails in couchdb (mail server puts mails that come in via SMTP into the DB, DB on the server replicates to my local DB, local DB is visible to mutt (a mail client) as a maildir), and for exposing the database as a maildir, this is exactly what I need! :+1: 
