### PR TITLE
Support for setxattr and statfs, unicode filenames

### DIFF
--- a/example/jsonFS.js
+++ b/example/jsonFS.js
@@ -390,24 +390,6 @@ function init(cb) {
 //---------------------------------------------------------------------------
 
 /*
- * Handler for the destroy() FUSE hook. You can perform clean up tasks here.
- * cb: a callback to call when you're done. It takes no arguments.
- */
-function destroy(cb) {
-  if (options.outJson) {
-    try {
-      fs.writeFileSync(options.outJson, JSON.stringify(obj, null, '  '), 'utf8');
-    } catch (e) {
-      console.log("Exception when writing file: " + e);
-    }
-  }
-  console.log("File system stopped");      
-  cb();
-}
-
-//---------------------------------------------------------------------------
-
-/*
  * Handler for the setxattr() FUSE hook. 
  * The arguments differ between different operating systems.
  * Darwin(Mac OSX):


### PR DESCRIPTION
Support for setxattr and statfs implementation so that Finder is able to copy files to fuse mount (free disk space).

Output of df -h:

```
node@fuse0     1.2Ti    0Bi  1.2Ti     0%         0 10000000    0% PATH
```

And I changed all String::AsciiValue calls to String::Utf8Value for unicode support.
