### PR TITLE
mirrorFS readLink properly follows relative links

### DIFF
--- a/example/mirrorFS.js
+++ b/example/mirrorFS.js
@@ -99,6 +99,7 @@ function readlink(path, cb) {
   return fs.readlink(path, function readlinkCb(err, name) {
     if (err)      
       return cb(-excToErrno(err));
+    var name = pth.resolve(srcRoot, name);
     return cb(0, name);
   });
 }


### PR DESCRIPTION
Bug in mirrorFS:

symlinks with a relative link (e.g. `jq -> ../Cellar/jq/1.3/bin/jq`) were linking relative to the mounted directory rather than the source directory. This was causing errors when trying to execute the symlink.
