### PR TITLE
add GenericFunc to OP_CHMOD args

### DIFF
--- a/fuse4js.cc
+++ b/fuse4js.cc
@@ -724,6 +724,7 @@ static void DispatchOp(uv_async_t* handle, int status)
 
   case OP_CHMOD:
     argv[argc++] = NanNew<Number>((double)f4js_cmd.u.chmod.mode);
+    argv[argc++] = NanNew(f4js.GenericFunc);
     break;
 
   case OP_SETXATTR:


### PR DESCRIPTION
Fixes #35.

It also looks like a few of these other OP's might also need this same treatment (i.e. "truncate"), though I haven't yet tested to verify that.
