### PR TITLE
fix compilation warning: missing field 'readlink' initializer

### DIFF
--- a/fuse4js.cc
+++ b/fuse4js.cc
@@ -381,7 +381,8 @@ void f4js_destroy (void *data)
 
 void *fuse_thread(void *)
 {
-  struct fuse_operations ops = { 0 };
+  struct fuse_operations ops;
+  memset(&ops, 0, sizeof(ops));
   ops.truncate = f4js_truncate;
   ops.getattr = f4js_getattr;
   ops.readdir = f4js_readdir;


### PR DESCRIPTION
in Clang:

```
  CXX(target) Release/obj.target/fuse4js/fuse4js.o
../fuse4js.cc:384:36: warning: missing field 'readlink' initializer [-Wmissing-field-initializers]
  struct fuse_operations ops = { 0 };
                                   ^
1 warning generated.
```
