### PR TITLE
add callback for truncate function

### DIFF
--- a/fuse4js.cc
+++ b/fuse4js.cc
@@ -708,6 +708,7 @@ static void DispatchOp(uv_async_t* handle, int status)
 
   case OP_TRUNCATE:
     argv[argc++] = NanNew((double)f4js_cmd.u.truncate.size);
+    argv[argc++] = NanNew(f4js.GenericFunc);
     break;
 
   case OP_GETATTR:


### PR DESCRIPTION
Before this change, truncate operations weren't passed the callback, so the operation would never complete. This adds the callback to the list of args, hopefully I didn't miss anything.
